### PR TITLE
fix: add missing numpy, scipy, scikit-image to install_requires (v1.1.2)

### DIFF
--- a/pdf2ocr/__init__.py
+++ b/pdf2ocr/__init__.py
@@ -84,4 +84,4 @@ Important Notes:
 - Supports graceful interruption and resume capabilities
 """
 
-__version__ = "1.1.1"
+__version__ = "1.1.2"

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,10 @@ setup(
     'reportlab>=4.0.0',
     'tqdm>=4.45.0',
     'Pillow>=9.0.0',
-    'pypdf>=3.15.0'
+    'pypdf>=3.15.0',
+    'numpy>=1.21.0',
+    'scipy>=1.7.0',
+    'scikit-image>=0.19.0'
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
## Summary

- `numpy`, `scipy`, and `scikit-image` were listed in `requirements.txt` but missing from `install_requires` in `setup.py`, causing a `No module named 'numpy'` error for users who installed via `pip install pdf2ocr`
- All three are used directly in the image preprocessing pipeline (`pdf2ocr/ocr.py`) and are required for OCR to function
- Bumped version to `1.1.2`

## What changed

- `setup.py`: added `numpy>=1.21.0`, `scipy>=1.7.0`, `scikit-image>=0.19.0` to `install_requires`
- `pdf2ocr/__init__.py`: version bumped from `1.1.1` → `1.1.2`

## Reviewer notes

No logic changes — dependency metadata fix only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)